### PR TITLE
Add/skip if exists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 *.jpg
+*.jpeg
 processed

--- a/main.go
+++ b/main.go
@@ -178,8 +178,8 @@ func listImages(dir string) (images []string, err error) {
 	return
 }
 
-// skip returns true if the file already exists and the mtime is greater than
-// the source image, false otherwhise.
+// skip returns an error if the file already exists and the mtime is greater than
+// the source image or if something fails in the checks.
 func skip(dir, path string) error {
 	dest := filepath.Join(dir, path)
 	// fail fast if not exist.


### PR DESCRIPTION
Solves issue #3 

The PR adds a skip with different conditions:
- if the `--force` flag is set, process anyway
- if the file does not exists, process
- if the file exists but the source file changed from last run, process it again (
- if the file exists and the destination file did not change, skip