### PR TITLE
fix: process in `WithForce` to set `force` value

### DIFF
--- a/letterbox.go
+++ b/letterbox.go
@@ -56,7 +56,7 @@ func WithWhiteBackground(v bool) Option {
 // WithForce changes whether or not to force re-processing of existing images.
 func WithForce(v bool) Option {
 	return func(p *Processor) error {
-		p.white = v
+		p.force = v
 		return nil
 	}
 }


### PR DESCRIPTION
Hi @tj, thank you for creating a convention tool to process photos.

When I first to add `-white` option, it can't set bg as white in my photo, so I delete photo and re-run original command with `-force` option it can work, but the interesting thing is: I deleted photo and re-run command with removed `-white` option and keep `-force` option, it still can set photo bg as white.

I feel something confuse. In my mind, when I created a processed picture and running the command without `-force`, I think it can't change photos.
